### PR TITLE
Add initial phase behaviour definition

### DIFF
--- a/src/rincewind_phase.erl
+++ b/src/rincewind_phase.erl
@@ -1,8 +1,33 @@
 -module(rincewind_phase).
 
 -type name() :: atom().
--type definition() :: #{name := name()}.
+-type init_arg() :: any().
+-type definition() ::
+    #{name := name(),
+      callback_module := module(),
+      init_arg => init_arg()}.
+-type callback_state() :: any().
+-type reason() :: any().
 
--opaque t() :: #{name := name()}.
+-opaque t() ::
+    #{name := name(),
+      callback_module := module(),
+      callback_state := callback_state()}.
 
--export_type([name/0, t/0, definition/0]).
+-export_type([name/0, init_arg/0, definition/0, callback_state/0, reason/0, t/0]).
+
+-callback init(init_arg() | undefined) -> {ok, callback_state()} | {error, reason()}.
+
+-export([new/1]).
+
+-spec new(definition()) -> t().
+new(#{name := Name, callback_module := CallbackModule} = Definition) ->
+    InitArg = maps:get(init_arg, Definition, undefined),
+    case CallbackModule:init(InitArg) of
+        {ok, InitState} ->
+            #{name => Name,
+              callback_module => CallbackModule,
+              callback_state => InitState};
+        {error, Reason} ->
+            erlang:error({invalid_phase, #{definition => Definition, error => Reason}})
+    end.

--- a/src/rincewind_sup.erl
+++ b/src/rincewind_sup.erl
@@ -19,7 +19,9 @@ start_wizard(Definition) ->
         {ok, _Pid} ->
             ok;
         {error, {already_started, _}} ->
-            {error, already_exists}
+            {error, already_exists};
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 -spec init(map()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.

--- a/test/test_phase.erl
+++ b/test/test_phase.erl
@@ -1,0 +1,12 @@
+-module(test_phase).
+
+-behaviour(rincewind_phase).
+
+-export([init/1]).
+
+-spec init(undefined) -> {ok, rincewind_phase:callback_state()};
+          (bad_init_arg) -> {error, bad_init_arg}.
+init(undefined) ->
+    {ok, phase_state};
+init(bad_init_arg) ->
+    {error, bad_init_arg}.

--- a/test/wizard_definition_SUITE.erl
+++ b/test/wizard_definition_SUITE.erl
@@ -3,10 +3,10 @@
 -behaviour(ct_suite).
 
 -export([all/0, init_per_suite/1, end_per_suite/1]).
--export([minimal/1, duplicated/1, complete_coverage/1]).
+-export([minimal/1, duplicated/1, bad_phase/1, complete_coverage/1]).
 
 all() ->
-    [minimal, duplicated, complete_coverage].
+    [minimal, duplicated, bad_phase, complete_coverage].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(rincewind),
@@ -17,7 +17,10 @@ end_per_suite(_) ->
     ok.
 
 minimal(_) ->
-    ok = rincewind:create_wizard(#{name => minimal, phases => [#{name => minimal_phase}]}),
+    ok =
+        rincewind:create_wizard(#{name => minimal,
+                                  phases =>
+                                      [#{name => minimal_phase, callback_module => test_phase}]}),
 
     %% You can inspect the wizard with the functions from rincewind_wizard
     MinimalWizard = rincewind:wizard(minimal),
@@ -28,15 +31,28 @@ minimal(_) ->
 
 %% @doc There cannot be two wizards with the same name
 duplicated(_) ->
-    Definition = #{name => duplicated, phases => [#{name => duplicated}]},
+    Definition =
+        #{name => duplicated, phases => [#{name => duplicated, callback_module => test_phase}]},
     ok = rincewind:create_wizard(Definition),
     {error, already_exists} = rincewind:create_wizard(Definition),
     ok = rincewind:kill_wizard(duplicated),
     ok = rincewind:create_wizard(Definition),
     ok.
 
+%% @doc Notice that test_phase:init/1 returns {error, bad_init_arg} if it receives bad_init_arg.
+bad_phase(_) ->
+    {error, {invalid_phase, #{error := bad_init_arg}}} =
+        rincewind:create_wizard(#{name => bad_phase,
+                                  phases =>
+                                      [#{name => bad,
+                                         callback_module => test_phase,
+                                         init_arg => bad_init_arg}]}),
+    ok.
+
 complete_coverage(_) ->
-    ok = rincewind:create_wizard(#{name => coverage, phases => [#{name => coverage}]}),
+    ok =
+        rincewind:create_wizard(#{name => coverage,
+                                  phases => [#{name => coverage, callback_module => test_phase}]}),
     ok = gen_server:cast(coverage, poison),
     %% The wizard died from the poison
     try rincewind:wizard(coverage) of


### PR DESCRIPTION
This PR introduces the behaviour called `rincewind_phase`, which will allow us to…

* Define different kinds of phases, each one with its own rules, inputs, results, etc.
* Showcase how to test a custom behaviour during the training.


Next step/PR: Implement rincewind_phase in the simplest way (either a text input, or multiple-choice, or option -i.e., radio buttons) and show how to write tests for a custom behaviour implementation.
After that one: Get the wizard running, implementing the movement through the phases.