### PR TITLE
Start/Stop runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ the wizard definition):
 
 ```erlang
 %% Get the full wizard definition (it can be used to navigate through the phases)
-#{name := WizardName, phases := […]} = rincewind:wizard_definition(WizardProcess),
+#{name := WizardName, phases := […]} = rincewind:wizard(WizardProcess),
 %% Skip the current phase
 {next_phase, #{phase := SecondPhaseName, …}} = rincewind:skip_phase(WizardProcess),
 %% Move back to a previous phase
 {next_phase, #{phase := FirstPhaseName, …}} = rincewind:jump_back(WizardProcess, FirstPhaseName),
 %% Get the current values of the wizard (i.e., the values chosen _so far_)
-[#{phase := FirstPhaseName, values := FirstPhaseValue, …}] = rincewind:get_values(WizardProcess),
+[#{phase := FirstPhaseName, values := FirstPhaseValue, …}] = rincewind:current_values(WizardProcess),
 ```
 
 [//]: # (TODO: Add more functions if we think we need them)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Once you have a user that wants to go through a wizard, you can manage their pro
 
 ```erlang
 %% Kick off the wizard process and get a reference for it
-{ok, WizardProcess} = rincewind:start(WizardName, UserName),
+{ok, WizardProcess} = rincewind:start_runner(WizardName, UserName),
 %% Get the fields and options for the current phase
 {ok, #{phase := FirstPhaseName, fields := […]}} = rincewind:current_phase(WizardProcess),
 %% Receive input from the user for the current phase (it returns the definition for the next phase, if there is one)

--- a/README.md
+++ b/README.md
@@ -44,17 +44,16 @@ Once you have a user that wants to go through a wizard, you can manage their pro
 ```erlang
 %% Kick off the wizard process and get a reference for it
 {ok, WizardProcess} = rincewind:start_runner(WizardName, UserName),
-%% Get the fields and options for the current phase
-{ok, #{phase := FirstPhaseName, fields := […]}} = rincewind:current_phase(WizardProcess),
+%% Get the options for the current phase
+%% Other than the name, the options for the current phase are up to the callback module that implements rincewind_phase
+{ok, #{name := FirstPhaseName, …}} = rincewind:current_phase(WizardProcess),
 %% Receive input from the user for the current phase (it returns the definition for the next phase, if there is one)
-{next_phase, #{phase := SecondPhaseName, fields := […]}} =
-    rincewind:submit(WizardProcess, #{phase => FirstPhaseName, field_values => […]}),
+%% The expected values depend on each phase's implementation
+{next_phase, #{name := SecondPhaseName, …}} = rincewind:submit(WizardProcess, Values),
 %% If the submitted values are deemed invalid, the corresponding validation errors are returned
-{invalid, #{phase := SecondPhaseName, field_errors := […]}} =
-    rincewind:submit(WizardProcess, #{phase => SecondPhaseName, field_values => […]}),
-%% If there are no further phases, the final result is returned
-{done, #{overall_result := OverallResult, phase_results := [#{phase := FirstPhaseName, value := FirstPhaseValue}, …]}} =
-    rincewind:submit(WizardProcess, #{phase => SecondPhaseName, field_values => […]}),
+{invalid, #{errors := …}} = rincewind:submit(WizardProcess, Values),
+%% If there are no further phases, the final values chosen for each phase are returned
+{done, [#{phase := FirstPhaseName, values := FirstPhaseValues}, …]} = rincewind:submit(WizardProcess, Values),
 ```
 
 While that's the happy path, Rincewind also provides the means for the user to jump through phases (if that's allowed by
@@ -64,17 +63,15 @@ the wizard definition):
 %% Get the full wizard definition (it can be used to navigate through the phases)
 #{name := WizardName, phases := […]} = rincewind:wizard_definition(WizardProcess),
 %% Skip the current phase
-{next_phase, #{phase := SecondPhaseName, fields := […]}} = rincewind:skip_phase(WizardProcess),
+{next_phase, #{phase := SecondPhaseName, …}} = rincewind:skip_phase(WizardProcess),
 %% Move back to a previous phase
-{next_phase, #{phase := FirstPhaseName, fields := […]}} = rincewind:jump_back(WizardProcess, FirstPhaseName),
-%% Get the current state of the wizard (i.e., the results _so far_)
-{ok, #{phase_results := [#{phase := FirstPhaseName, value := FirstPhaseValue}, …]}} = rincewind:get_state(WizardProcess),
+{next_phase, #{phase := FirstPhaseName, …}} = rincewind:jump_back(WizardProcess, FirstPhaseName),
+%% Get the current values of the wizard (i.e., the values chosen _so far_)
+[#{phase := FirstPhaseName, values := FirstPhaseValue, …}] = rincewind:get_values(WizardProcess),
 ```
 
 [//]: # (TODO: Add more functions if we think we need them)
 
 [//]: # (TODO: If we add a folder with examples, link it here)
-
-## Implementation
 
 [//]: # (TODO: Add implementation details that can be useful for our users, like the fact that each process is an FSM or something)

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ the wizard definition):
 #{name := WizardName, phases := […]} = rincewind:wizard(WizardProcess),
 %% Skip the current phase
 {next_phase, #{phase := SecondPhaseName, …}} = rincewind:skip_phase(WizardProcess),
-%% Move back to a previous phase
-{next_phase, #{phase := FirstPhaseName, …}} = rincewind:jump_back(WizardProcess, FirstPhaseName),
+%% Move back to the previous phase
+{next_phase, #{phase := FirstPhaseName, …}} = rincewind:jump_back(WizardProcess),
 %% Get the current values of the wizard (i.e., the values chosen _so far_)
 [#{phase := FirstPhaseName, values := FirstPhaseValue, …}] = rincewind:current_values(WizardProcess),
 ```

--- a/src/rincewind.erl
+++ b/src/rincewind.erl
@@ -4,7 +4,8 @@
 
 -export([start/2, stop/1]).
 -export([create_wizard/1, kill_wizard/1, wizard/1]).
--export([start_runner/2, current_phase/1, submit/2, stop_runner/1]).
+-export([start_runner/2, current_phase/1, current_values/1, submit/2, skip_phase/1,
+         stop_runner/1]).
 
 %% @private
 -spec start(application:start_type(), map()) -> {ok, pid()}.
@@ -38,6 +39,10 @@ start_runner(WizardName, RunnerName) ->
 current_phase(RunnerRef) ->
     rincewind_runner:current_phase(RunnerRef).
 
+-spec current_values(rincewind_runner:ref()) -> [rincewind_runner:result(), ...].
+current_values(RunnerRef) ->
+    rincewind_runner:current_values(RunnerRef).
+
 -spec submit(rincewind_runner:ref(), rincewind_phase:values()) ->
                 {invalid, rincewind_phase:validation_error()} |
                 {error, done} |
@@ -45,6 +50,15 @@ current_phase(RunnerRef) ->
                 {done, [rincewind_runner:result(), ...]}.
 submit(RunnerRef, Values) ->
     rincewind_runner:submit(RunnerRef, Values).
+
+%% @todo Consider if there are phases that can't be skipped
+%%       unless they already have selected values)
+-spec skip_phase(rincewind_runner:ref()) ->
+                    {error, done} |
+                    {next_phase, rincewind_phase:t()} |
+                    {done, [rincewind_runner:result(), ...]}.
+skip_phase(RunnerRef) ->
+    rincewind_runner:skip_phase(RunnerRef).
 
 -spec stop_runner(rincewind_runner:ref()) -> ok.
 stop_runner(RunnerRef) ->

--- a/src/rincewind.erl
+++ b/src/rincewind.erl
@@ -4,7 +4,7 @@
 
 -export([start/2, stop/1]).
 -export([create_wizard/1, kill_wizard/1, wizard/1]).
--export([start_runner/2, stop_runner/1]).
+-export([start_runner/2, current_phase/1, stop_runner/1]).
 
 %% @private
 -spec start(application:start_type(), map()) -> {ok, pid()}.
@@ -33,6 +33,10 @@ wizard(WizardName) ->
                       {ok, rincewind_runner:ref()} | {error, rincewind_runner_sup:creation_error()}.
 start_runner(WizardName, RunnerName) ->
     rincewind_runner_sup:start_runner(WizardName, RunnerName).
+
+-spec current_phase(rincewind_runner:ref()) -> rincewind_phase:t().
+current_phase(RunnerRef) ->
+    rincewind_runner:current_phase(RunnerRef).
 
 -spec stop_runner(rincewind_runner:ref()) -> ok.
 stop_runner(RunnerRef) ->

--- a/src/rincewind.erl
+++ b/src/rincewind.erl
@@ -5,7 +5,7 @@
 -export([start/2, stop/1]).
 -export([create_wizard/1, kill_wizard/1, wizard/1]).
 -export([start_runner/2, current_phase/1, current_values/1, submit/2, skip_phase/1,
-         stop_runner/1]).
+         jump_back/1, stop_runner/1]).
 
 %% @private
 -spec start(application:start_type(), map()) -> {ok, pid()}.
@@ -52,13 +52,20 @@ submit(RunnerRef, Values) ->
     rincewind_runner:submit(RunnerRef, Values).
 
 %% @todo Consider if there are phases that can't be skipped
-%%       unless they already have selected values)
+%%       (Maybe unless they already have selected values)
 -spec skip_phase(rincewind_runner:ref()) ->
                     {error, done} |
                     {next_phase, rincewind_phase:t()} |
                     {done, [rincewind_runner:result(), ...]}.
 skip_phase(RunnerRef) ->
     rincewind_runner:skip_phase(RunnerRef).
+
+%% @todo Consider if there are phases that can't jump back
+%% @todo Consider jumping back and forth as many steps as desired
+-spec jump_back(rincewind_runner:ref()) ->
+                   {error, no_previous_phase} | {next_phase, rincewind_phase:t()}.
+jump_back(RunnerRef) ->
+    rincewind_runner:jump_back(RunnerRef).
 
 -spec stop_runner(rincewind_runner:ref()) -> ok.
 stop_runner(RunnerRef) ->

--- a/src/rincewind.erl
+++ b/src/rincewind.erl
@@ -4,6 +4,7 @@
 
 -export([start/2, stop/1]).
 -export([create_wizard/1, kill_wizard/1, wizard/1]).
+-export([start_runner/2, stop_runner/1]).
 
 %% @private
 -spec start(application:start_type(), map()) -> {ok, pid()}.
@@ -16,9 +17,9 @@ stop([]) ->
     ok.
 
 -spec create_wizard(rincewind_wizard:definition()) ->
-                       ok | {error, rincewind_sup:creation_error()}.
+                       ok | {error, rincewind_wizard_sup:creation_error()}.
 create_wizard(Wizard) ->
-    rincewind_sup:start_wizard(Wizard).
+    rincewind_wizard_sup:start_wizard(Wizard).
 
 -spec kill_wizard(rincewind_wizard:name()) -> ok.
 kill_wizard(WizardName) ->
@@ -27,3 +28,12 @@ kill_wizard(WizardName) ->
 -spec wizard(rincewind_wizard:name()) -> rincewind_wizard:t().
 wizard(WizardName) ->
     rincewind_wizard:definition(WizardName).
+
+-spec start_runner(rincewind_wizard:name(), rincewind_runner:name()) ->
+                      {ok, rincewind_runner:ref()} | {error, rincewind_runner_sup:creation_error()}.
+start_runner(WizardName, RunnerName) ->
+    rincewind_runner_sup:start_runner(WizardName, RunnerName).
+
+-spec stop_runner(rincewind_runner:ref()) -> ok.
+stop_runner(RunnerRef) ->
+    rincewind_runner:stop(RunnerRef).

--- a/src/rincewind.erl
+++ b/src/rincewind.erl
@@ -4,7 +4,7 @@
 
 -export([start/2, stop/1]).
 -export([create_wizard/1, kill_wizard/1, wizard/1]).
--export([start_runner/2, current_phase/1, stop_runner/1]).
+-export([start_runner/2, current_phase/1, submit/2, stop_runner/1]).
 
 %% @private
 -spec start(application:start_type(), map()) -> {ok, pid()}.
@@ -34,9 +34,17 @@ wizard(WizardName) ->
 start_runner(WizardName, RunnerName) ->
     rincewind_runner_sup:start_runner(WizardName, RunnerName).
 
--spec current_phase(rincewind_runner:ref()) -> rincewind_phase:t().
+-spec current_phase(rincewind_runner:ref()) -> done | rincewind_phase:t().
 current_phase(RunnerRef) ->
     rincewind_runner:current_phase(RunnerRef).
+
+-spec submit(rincewind_runner:ref(), rincewind_phase:values()) ->
+                {invalid, rincewind_phase:validation_error()} |
+                {error, done} |
+                {next_phase, rincewind_phase:t()} |
+                {done, [rincewind_runner:result(), ...]}.
+submit(RunnerRef, Values) ->
+    rincewind_runner:submit(RunnerRef, Values).
 
 -spec stop_runner(rincewind_runner:ref()) -> ok.
 stop_runner(RunnerRef) ->

--- a/src/rincewind_phase.erl
+++ b/src/rincewind_phase.erl
@@ -19,6 +19,7 @@
 -callback init(init_arg() | undefined) -> {ok, callback_state()} | {error, reason()}.
 
 -export([new/1]).
+-export([name/1]).
 
 -spec new(definition()) -> t().
 new(#{name := Name, callback_module := CallbackModule} = Definition) ->
@@ -31,3 +32,7 @@ new(#{name := Name, callback_module := CallbackModule} = Definition) ->
         {error, Reason} ->
             erlang:error({invalid_phase, #{definition => Definition, error => Reason}})
     end.
+
+-spec name(t()) -> name().
+name(#{name := Name}) ->
+    Name.

--- a/src/rincewind_phase.erl
+++ b/src/rincewind_phase.erl
@@ -8,18 +8,22 @@
       init_arg => init_arg()}.
 -type callback_state() :: any().
 -type reason() :: any().
+-type validation_error() :: any().
+-type values() :: any().
 
 -opaque t() ::
     #{name := name(),
       callback_module := module(),
       callback_state := callback_state()}.
 
--export_type([name/0, init_arg/0, definition/0, callback_state/0, reason/0, t/0]).
+-export_type([name/0, init_arg/0, definition/0, callback_state/0, reason/0,
+              validation_error/0, values/0, t/0]).
 
 -callback init(init_arg() | undefined) -> {ok, callback_state()} | {error, reason()}.
+-callback validate(values(), callback_state()) -> valid | {invalid, validation_error()}.
 
 -export([new/1]).
--export([name/1]).
+-export([name/1, validate/2]).
 
 -spec new(definition()) -> t().
 new(#{name := Name, callback_module := CallbackModule} = Definition) ->
@@ -36,3 +40,7 @@ new(#{name := Name, callback_module := CallbackModule} = Definition) ->
 -spec name(t()) -> name().
 name(#{name := Name}) ->
     Name.
+
+-spec validate(t(), values()) -> valid | {invalid, validation_error()}.
+validate(#{callback_module := Module, callback_state := State}, Values) ->
+    Module:validate(Values, State).

--- a/src/rincewind_runner.erl
+++ b/src/rincewind_runner.erl
@@ -1,0 +1,38 @@
+-module(rincewind_runner).
+
+-behaviour(gen_server).
+
+-type name() :: atom().
+
+-opaque ref() :: pid().
+-opaque t() :: #{name := name(), wizard := rincewind_wizard:t()}.
+
+-export_type([name/0, ref/0, t/0]).
+
+-export([start_link/2, stop/1]).
+-export([init/1, handle_call/3, handle_cast/2]).
+
+-spec start_link(rincewind_wizard:t(), name()) ->
+                    {ok, ref()} | {error, rincewind_runner_sup:creation_error()}.
+start_link(Wizard, RunnerName) ->
+    ProcessName =
+        binary_to_atom(iolist_to_binary(io_lib:format("rincewind_runner-~p-~p",
+                                                      [rincewind_wizard:name(Wizard),
+                                                       RunnerName]))),
+    gen_server:start_link({local, ProcessName},
+                          rincewind_runner,
+                          #{wizard => Wizard, name => RunnerName},
+                          []).
+
+-spec stop(ref()) -> ok.
+stop(RunnerPid) ->
+    gen_server:stop(RunnerPid).
+
+init(#{name := Name, wizard := Wizard}) ->
+    {ok, #{name => Name, wizard => Wizard}}.
+
+handle_call(Msg, _From, Runner) ->
+    {stop, {unexpected_call, Msg}, Runner}.
+
+handle_cast(Msg, Runner) ->
+    {stop, {unexpected_cast, Msg}, Runner}.

--- a/src/rincewind_runner.erl
+++ b/src/rincewind_runner.erl
@@ -5,12 +5,16 @@
 -type name() :: atom().
 
 -opaque ref() :: pid().
--opaque t() :: #{name := name(), wizard := rincewind_wizard:t()}.
+-opaque t() ::
+    #{name := name(),
+      wizard := rincewind_wizard:t(),
+      phase := rincewind_phase:t()}.
 
 -export_type([name/0, ref/0, t/0]).
 
 -export([start_link/2, stop/1]).
 -export([init/1, handle_call/3, handle_cast/2]).
+-export([current_phase/1]).
 
 -spec start_link(rincewind_wizard:t(), name()) ->
                     {ok, ref()} | {error, rincewind_runner_sup:creation_error()}.
@@ -24,15 +28,22 @@ start_link(Wizard, RunnerName) ->
                           #{wizard => Wizard, name => RunnerName},
                           []).
 
+-spec current_phase(ref()) -> rincewind_phase:t().
+current_phase(RunnerPid) ->
+    gen_server:call(RunnerPid, current_phase).
+
 -spec stop(ref()) -> ok.
 stop(RunnerPid) ->
     gen_server:stop(RunnerPid).
 
 init(#{name := Name, wizard := Wizard}) ->
-    {ok, #{name => Name, wizard => Wizard}}.
+    {ok,
+     #{name => Name,
+       wizard => Wizard,
+       phase => hd(rincewind_wizard:phases(Wizard))}}.
 
-handle_call(Msg, _From, Runner) ->
-    {stop, {unexpected_call, Msg}, Runner}.
+handle_call(current_phase, _From, #{phase := CurrentPhase} = Runner) ->
+    {reply, CurrentPhase, Runner}.
 
 handle_cast(Msg, Runner) ->
     {stop, {unexpected_cast, Msg}, Runner}.

--- a/src/rincewind_runner.erl
+++ b/src/rincewind_runner.erl
@@ -5,16 +5,20 @@
 -type name() :: atom().
 
 -opaque ref() :: pid().
+
+-type result() :: #{phase := rincewind_phase:t(), values := rincewind_phase:values()}.
+
 -opaque t() ::
     #{name := name(),
       wizard := rincewind_wizard:t(),
-      phase := rincewind_phase:t()}.
+      phase_number := pos_integer() | done,
+      values := [not_chosen | {chosen, rincewind_phase:values()}]}.
 
--export_type([name/0, ref/0, t/0]).
+-export_type([name/0, ref/0, result/0, t/0]).
 
 -export([start_link/2, stop/1]).
 -export([init/1, handle_call/3, handle_cast/2]).
--export([current_phase/1]).
+-export([current_phase/1, submit/2]).
 
 -spec start_link(rincewind_wizard:t(), name()) ->
                     {ok, ref()} | {error, rincewind_runner_sup:creation_error()}.
@@ -28,9 +32,17 @@ start_link(Wizard, RunnerName) ->
                           #{wizard => Wizard, name => RunnerName},
                           []).
 
--spec current_phase(ref()) -> rincewind_phase:t().
+-spec current_phase(ref()) -> done | rincewind_phase:t().
 current_phase(RunnerPid) ->
     gen_server:call(RunnerPid, current_phase).
+
+-spec submit(ref(), rincewind_phase:values()) ->
+                {invalid, rincewind_phase:validation_error()} |
+                {error, done} |
+                {next_phase, rincewind_phase:t()} |
+                {done, [result(), ...]}.
+submit(RunnerRef, Values) ->
+    gen_server:call(RunnerRef, {submit, Values}).
 
 -spec stop(ref()) -> ok.
 stop(RunnerPid) ->
@@ -40,10 +52,55 @@ init(#{name := Name, wizard := Wizard}) ->
     {ok,
      #{name => Name,
        wizard => Wizard,
-       phase => hd(rincewind_wizard:phases(Wizard))}}.
+       values => lists:duplicate(length(rincewind_wizard:phases(Wizard)), not_chosen),
+       phase_number => 1}}.
 
-handle_call(current_phase, _From, #{phase := CurrentPhase} = Runner) ->
-    {reply, CurrentPhase, Runner}.
+handle_call(current_phase, _From, #{phase_number := done} = Runner) ->
+    {reply, done, Runner};
+handle_call(current_phase,
+            _From,
+            #{phase_number := CurrentPhase, wizard := Wizard} = Runner) ->
+    {reply, lists:nth(CurrentPhase, rincewind_wizard:phases(Wizard)), Runner};
+handle_call({submit, _}, _From, #{phase_number := done} = Runner) ->
+    {reply, {error, done}, Runner};
+handle_call({submit, SelectedValues},
+            _From,
+            #{phase_number := CurrentPhaseNumber,
+              values := Values,
+              wizard := Wizard} =
+                Runner) ->
+    WizardPhases = rincewind_wizard:phases(Wizard),
+    CurrentPhase = lists:nth(CurrentPhaseNumber, WizardPhases),
+    %% @todo Consider at some point, the need to pass the current value,
+    %%       or the values of the previous phases,
+    %%       or even the entire wizard to this function.
+    %%       Also worth considering if the phase would like to transform
+    %%       the selected values (e.g., it receives numbers and returns strings)
+    case rincewind_phase:validate(CurrentPhase, SelectedValues) of
+        valid ->
+            {UpToCurrentPhase, NextPhases} = lists:split(CurrentPhaseNumber, Values),
+            [_ | PreviousPhases] = lists:reverse(UpToCurrentPhase),
+            NewValues = lists:reverse(PreviousPhases) ++ [{chosen, SelectedValues} | NextPhases],
+            case length(WizardPhases) of
+                CurrentPhaseNumber -> %% this was the last one
+                    Result =
+                        lists:zipwith(fun build_result/2,
+                                      rincewind_wizard:phases(Wizard),
+                                      NewValues),
+                    {reply, {done, Result}, Runner#{phase_number := done, values := NewValues}};
+                _ ->
+                    {reply,
+                     {next_phase, lists:nth(CurrentPhaseNumber + 1, WizardPhases)},
+                     Runner#{phase_number := CurrentPhaseNumber + 1, values := NewValues}}
+            end;
+        {invalid, ValidationError} ->
+            {reply, {invalid, ValidationError}, Runner}
+    end.
 
 handle_cast(Msg, Runner) ->
     {stop, {unexpected_cast, Msg}, Runner}.
+
+build_result(Phase, not_chosen) ->
+    #{phase => Phase};
+build_result(Phase, {chosen, Values}) ->
+    #{phase => Phase, values => Values}.

--- a/src/rincewind_runner_sup.erl
+++ b/src/rincewind_runner_sup.erl
@@ -1,0 +1,40 @@
+-module(rincewind_runner_sup).
+
+-behaviour(supervisor).
+
+-type creation_error() :: {already_started, rincewind_runner:ref()} | invalid_wizard.
+
+-export_type([creation_error/0]).
+
+-export([start_link/0, start_runner/2]).
+-export([init/1]).
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    supervisor:start_link({local, rincewind_runner_sup}, rincewind_runner_sup, #{}).
+
+-spec start_runner(rincewind_wizard:name(), rincewind_runner:name()) ->
+                      {ok, rincewind_runner:ref()} | {error, creation_error()}.
+start_runner(WizardName, RunnerName) ->
+    try rincewind:wizard(WizardName) of
+        Wizard ->
+            supervisor:start_child(rincewind_runner_sup, [Wizard, RunnerName])
+    catch
+        _:{noproc, _} ->
+            {error, invalid_wizard}
+    end.
+
+-spec init(map()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init(#{}) ->
+    SupFlags =
+        #{strategy => simple_one_for_one,
+          intensity => 1000,
+          period => 3600},
+
+    Children =
+        [#{id => rincewind_runner,
+           start => {rincewind_runner, start_link, []},
+           restart => transient,
+           modules => [rincewind_runner]}],
+
+    {ok, {SupFlags, Children}}.

--- a/src/rincewind_sup.erl
+++ b/src/rincewind_sup.erl
@@ -2,39 +2,21 @@
 
 -behaviour(supervisor).
 
--type creation_error() :: already_exists.
-
--export_type([creation_error/0]).
-
--export([start_link/0, start_wizard/1]).
+-export([start_link/0]).
 -export([init/1]).
 
 -spec start_link() -> {ok, pid()}.
 start_link() ->
     supervisor:start_link({local, rincewind_sup}, rincewind_sup, #{}).
 
--spec start_wizard(rincewind_wizard:definition()) -> ok | {error, creation_error()}.
-start_wizard(Definition) ->
-    case supervisor:start_child(rincewind_sup, [Definition]) of
-        {ok, _Pid} ->
-            ok;
-        {error, {already_started, _}} ->
-            {error, already_exists};
-        {error, Reason} ->
-            {error, Reason}
-    end.
-
 -spec init(map()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init(#{}) ->
-    SupFlags =
-        #{strategy => simple_one_for_one,
-          intensity => 1000,
-          period => 3600},
-
     Children =
-        [#{id => rincewind_wizard,
-           start => {rincewind_wizard, start_link, []},
-           restart => transient,
-           modules => [rincewind_wizard]}],
+        [#{id => rincewind_wizard_sup,
+           start => {rincewind_wizard_sup, start_link, []},
+           type => supervisor},
+         #{id => rincewind_runner_sup,
+           start => {rincewind_runner_sup, start_link, []},
+           type => supervisor}],
 
-    {ok, {SupFlags, Children}}.
+    {ok, {#{}, Children}}.

--- a/src/rincewind_wizard.erl
+++ b/src/rincewind_wizard.erl
@@ -18,7 +18,7 @@
 name(#{name := Name}) ->
     Name.
 
--spec phases(t()) -> [rincewind_phase:t()].
+-spec phases(t()) -> [rincewind_phase:t(), ...].
 phases(#{phases := Phases}) ->
     Phases.
 

--- a/test/test_phase.erl
+++ b/test/test_phase.erl
@@ -5,8 +5,11 @@
 -export([init/1]).
 
 -spec init(undefined) -> {ok, rincewind_phase:callback_state()};
+          (binary()) -> {ok, rincewind_phase:callback_state()};
           (bad_init_arg) -> {error, bad_init_arg}.
 init(undefined) ->
     {ok, phase_state};
+init(<<PhaseTitle/binary>>) ->
+    {ok, #{title => PhaseTitle}};
 init(bad_init_arg) ->
     {error, bad_init_arg}.

--- a/test/test_phase.erl
+++ b/test/test_phase.erl
@@ -16,7 +16,11 @@ init(bad_init_arg) ->
 
 -spec validate(binary(), #{title := binary()}) ->
                   valid | {invalid, #{expected := binary(), got := binary()}}.
-validate(Value, #{title := Value}) ->
-    valid;
 validate(Value, #{title := Title}) ->
-    {invalid, #{expected => Title, got => Value}}.
+    Len = size(Title),
+    case Value of
+        <<Title:Len/binary, _/binary>> ->
+            valid;
+        _ ->
+            {invalid, #{expected => Title, got => Value}}
+    end.

--- a/test/test_phase.erl
+++ b/test/test_phase.erl
@@ -2,7 +2,7 @@
 
 -behaviour(rincewind_phase).
 
--export([init/1]).
+-export([init/1, validate/2]).
 
 -spec init(undefined) -> {ok, rincewind_phase:callback_state()};
           (binary()) -> {ok, rincewind_phase:callback_state()};
@@ -13,3 +13,10 @@ init(<<PhaseTitle/binary>>) ->
     {ok, #{title => PhaseTitle}};
 init(bad_init_arg) ->
     {error, bad_init_arg}.
+
+-spec validate(binary(), #{title := binary()}) ->
+                  valid | {invalid, #{expected := binary(), got := binary()}}.
+validate(Value, #{title := Value}) ->
+    valid;
+validate(Value, #{title := Title}) ->
+    {invalid, #{expected => Title, got => Value}}.

--- a/test/wizard_usage_SUITE.erl
+++ b/test/wizard_usage_SUITE.erl
@@ -4,10 +4,10 @@
 
 -export([all/0, init_per_suite/1, init_per_testcase/2, end_per_testcase/2,
          end_per_suite/1]).
--export([invalid_wizard/1, start_stop/1, complete_coverage/1]).
+-export([invalid_wizard/1, start_stop/1, first_phase/1, complete_coverage/1]).
 
 all() ->
-    [invalid_wizard, start_stop, complete_coverage].
+    [invalid_wizard, start_stop, first_phase, complete_coverage].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(rincewind),
@@ -24,6 +24,22 @@ init_per_testcase(TestCase, Config)
         rincewind:create_wizard(#{name => TestCase,
                                   phases =>
                                       [#{name => test_phase, callback_module => test_phase}]}),
+    Config;
+init_per_testcase(TestCase, Config) ->
+    %% For other tests we need a fully functional wizard, with three phases
+    %% To check the implementation of each phase (they're all similar anyway, check test_phase)
+    ok =
+        rincewind:create_wizard(#{name => TestCase,
+                                  phases =>
+                                      [#{name => first_phase,
+                                         callback_module => test_phase,
+                                         init_arg => <<"First">>},
+                                       #{name => second_phase,
+                                         callback_module => test_phase,
+                                         init_arg => <<"Second">>},
+                                       #{name => third_phase,
+                                         callback_module => test_phase,
+                                         init_arg => <<"Third">>}]}),
     Config.
 
 end_per_testcase(invalid_wizard, Config) ->
@@ -48,6 +64,13 @@ start_stop(_) ->
     {ok, NewWizardProcess} = rincewind:start_runner(start_stop, user_id),
     ok = rincewind:stop_runner(NewWizardProcess).
 
+first_phase(_) ->
+    {ok, WizardProcess} = rincewind:start_runner(first_phase, user_id),
+    %% The runner just started, the user should see the first phase as the current phase
+    FirstPhase = rincewind:current_phase(WizardProcess),
+    first_phase = rincewind_phase:name(FirstPhase),
+    ok.
+
 complete_coverage(_) ->
     {ok, WizardProcess1} = rincewind:start_runner(complete_coverage, user_id),
     ok = gen_server:cast(WizardProcess1, poison),
@@ -58,22 +81,4 @@ complete_coverage(_) ->
     catch
         _:Reason ->
             {{unexpected_cast, poison}, _} = Reason
-    end,
-
-    {ok, WizardProcess2} = rincewind:start_runner(complete_coverage, another_user_id),
-    try gen_server:call(WizardProcess2, dagger) of
-        Response ->
-            ct:fail("~p should not be alive: ~p", [WizardProcess2, Response])
-    catch
-        _:CallReason ->
-            {{unexpected_call, dagger}, _} = CallReason
-    end,
-
-    %% The runner died as well
-    try sys:get_status(WizardProcess2) of
-        Status2 ->
-            ct:fail("~p should not be alive: ~p", [WizardProcess2, Status2])
-    catch
-        _:OtherReason ->
-            {noproc, _} = OtherReason
     end.

--- a/test/wizard_usage_SUITE.erl
+++ b/test/wizard_usage_SUITE.erl
@@ -1,0 +1,79 @@
+-module(wizard_usage_SUITE).
+
+-behaviour(ct_suite).
+
+-export([all/0, init_per_suite/1, init_per_testcase/2, end_per_testcase/2,
+         end_per_suite/1]).
+-export([invalid_wizard/1, start_stop/1, complete_coverage/1]).
+
+all() ->
+    [invalid_wizard, start_stop, complete_coverage].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(rincewind),
+    Config.
+
+init_per_testcase(invalid_wizard, Config) ->
+    %% No wizard needs to be created for this test
+    Config;
+init_per_testcase(TestCase, Config)
+    when TestCase == start_stop; TestCase == complete_coverage ->
+    %% For start_stop/1 and complete_coverage/1 we just need a wizard.
+    %% The actual phases are not important.
+    ok =
+        rincewind:create_wizard(#{name => TestCase,
+                                  phases =>
+                                      [#{name => test_phase, callback_module => test_phase}]}),
+    Config.
+
+end_per_testcase(invalid_wizard, Config) ->
+    Config;
+end_per_testcase(TestCase, Config) ->
+    ok = rincewind:kill_wizard(TestCase),
+    Config.
+
+end_per_suite(_) ->
+    ok = application:stop(rincewind),
+    ok.
+
+invalid_wizard(_) ->
+    {error, invalid_wizard} = rincewind:start_runner(invalid_wizard, user_id).
+
+start_stop(_) ->
+    ct:log("~p", [supervisor:which_children(rincewind_sup)]),
+    {ok, WizardProcess} = rincewind:start_runner(start_stop, user_id),
+    %% We allow a single process for user
+    {error, {already_started, WizardProcess}} = rincewind:start_runner(start_stop, user_id),
+    ok = rincewind:stop_runner(WizardProcess),
+    {ok, NewWizardProcess} = rincewind:start_runner(start_stop, user_id),
+    ok = rincewind:stop_runner(NewWizardProcess).
+
+complete_coverage(_) ->
+    {ok, WizardProcess1} = rincewind:start_runner(complete_coverage, user_id),
+    ok = gen_server:cast(WizardProcess1, poison),
+    %% The runner died from the poison
+    try sys:get_status(WizardProcess1) of
+        Status ->
+            ct:fail("~p should not be alive: ~p", [WizardProcess1, Status])
+    catch
+        _:Reason ->
+            {{unexpected_cast, poison}, _} = Reason
+    end,
+
+    {ok, WizardProcess2} = rincewind:start_runner(complete_coverage, another_user_id),
+    try gen_server:call(WizardProcess2, dagger) of
+        Response ->
+            ct:fail("~p should not be alive: ~p", [WizardProcess2, Response])
+    catch
+        _:CallReason ->
+            {{unexpected_call, dagger}, _} = CallReason
+    end,
+
+    %% The runner died as well
+    try sys:get_status(WizardProcess2) of
+        Status2 ->
+            ct:fail("~p should not be alive: ~p", [WizardProcess2, Status2])
+    catch
+        _:OtherReason ->
+            {noproc, _} = OtherReason
+    end.


### PR DESCRIPTION
It was trickier than what I anticipated… mostly because wizard definitions should probably be better kept in either `ets` or `persistent_term`. There is really no need for them to be processes. But I didn't want to undo my previous steps… yet.